### PR TITLE
Fix base64 encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ deploy:
   on:
     branch: master
     repo: sammygriffiths/frinkiac-gif-generator
+    tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frinkiac-gif-generator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generate Simpsons gifs based on a search term from frinkiac.com",
   "main": "index.js",
   "scripts": {

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-const wrap = require('word-wrap');
+const helpers = require('./helpers');
 
 module.exports = axios => {
     const api = {
@@ -53,8 +53,7 @@ module.exports = axios => {
         },
         getGifFromSubtitle: subtitle => {
             let gif;
-            let wrappedText = wrap(subtitle.Content, {width: 28, indent: ''});
-            let subtitleText = Buffer.from(wrappedText).toString('base64');
+            let subtitleText = helpers.formatSubtitleText(subtitle.Content);
 
             return new Promise(async (resolve, reject) => {
                 try {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,14 @@
+const wrap = require('word-wrap');
+
+const helpers = {
+    formatSubtitleText: (text) => {
+        let wrappedText = wrap(text, { width: 28, indent: '' });
+        let subtitleText = Buffer.from(wrappedText).toString('base64');
+        let replacedSlashText = subtitleText.replace(/\//g, '_');
+        let replacedPlusText = replacedSlashText.replace(/\+/g, '-');
+
+        return replacedPlusText;
+    }
+}
+
+module.exports = helpers;

--- a/test/src/api.test.js
+++ b/test/src/api.test.js
@@ -126,33 +126,8 @@ describe('API', () => {
             sinon.assert.calledWith(axios.get, expectedUrl);
         });
 
-        it('base64 encodes the text', () => {
-            let subtitle = {
-                Episode: 'S07E21',
-                StartTimestamp: '1',
-                EndTimestamp: '2',
-                Content: 'text'
-            };
-
-            let expectedUrl = 'https://frinkiac.com/gif/S07E21/1/2.gif?b64lines=dGV4dA==';
-
-            const axios = {
-                get: sinon.stub().resolves({
-                    request: {
-                        res: {
-                            responseUrl: 'gif'
-                        }
-                    }
-                })
-            };
-
-            api(axios).getGifFromSubtitle(subtitle);
-
-            sinon.assert.calledWith(axios.get, expectedUrl);
-        });
-
-        it('adds line breaks in the text where appropriate', () => {
-            let text = 'This is a long piece of text that needs to be split on to multiple lines';
+        it('formats the subtitle text', () => {
+            let text = 'This is a long piece of text that needs to be split on to multiple lines?????>>>>>';
             let subtitle = {
                 Episode: 'S07E21',
                 StartTimestamp: '1',
@@ -160,7 +135,7 @@ describe('API', () => {
                 Content: text
             };
 
-            let expectedText = 'VGhpcyBpcyBhIGxvbmcgcGllY2Ugb2YgdGV4dCAKdGhhdCBuZWVkcyB0byBiZSBzcGxpdCBvbiB0byAKbXVsdGlwbGUgbGluZXM=';
+            let expectedText = 'VGhpcyBpcyBhIGxvbmcgcGllY2Ugb2YgdGV4dCAKdGhhdCBuZWVkcyB0byBiZSBzcGxpdCBvbiB0byAKbXVsdGlwbGUgbGluZXM_Pz8_Pz4-Pj4-';
             let expectedUrl = 'https://frinkiac.com/gif/S07E21/1/2.gif?b64lines=' + expectedText;
 
             const axios = {
@@ -206,6 +181,15 @@ describe('API', () => {
         it('gets the appropriate gif from frinkiac', async () => {
             let expectedUrl = 'https://frinkiac.com/video/S10E07/MI9Rd6R0gNkiZnr2cFb_wA8vC3k=.gif';
             let term = 'super nintendo chalmers';
+            
+            let result = await api(require('axios')).generateGif(term);
+
+            expect(result).to.equal(expectedUrl);
+        }).timeout(10000);
+
+        it('gets the appropriate gif from frinkiac even with bad characters in the base64 text', async () => {
+            let expectedUrl = 'https://frinkiac.com/video/S05E14/ZqdztxjYgowA0n-pHNj6OVp6Ymc=.gif';
+            let term = 'my spidey sense is tingling';
             
             let result = await api(require('axios')).generateGif(term);
 

--- a/test/src/helpers.test.js
+++ b/test/src/helpers.test.js
@@ -1,0 +1,42 @@
+const expect = require('chai').expect;
+const helpers = require('../../src/helpers');
+
+describe('helpers', () => {
+    describe('formatSubtitleText', () => {
+        it('base64 encodes the text', () => {
+            let text = 'text';
+            let expectedText = 'dGV4dA==';
+            
+            let returnedText = helpers.formatSubtitleText(text);
+
+            expect(returnedText).to.equal(expectedText);
+        });
+
+        it('adds line breaks in the text where appropriate', () => {
+            let text = 'This is a long piece of text that needs to be split on to multiple lines';
+            let expectedText = 'VGhpcyBpcyBhIGxvbmcgcGllY2Ugb2YgdGV4dCAKdGhhdCBuZWVkcyB0byBiZSBzcGxpdCBvbiB0byAKbXVsdGlwbGUgbGluZXM=';
+
+            let returnedText = helpers.formatSubtitleText(text);
+
+            expect(returnedText).to.equal(expectedText);
+        });
+
+        it('replaces all returned / symbols with _', () => {
+            let text = '??????';
+            let expectedText = 'Pz8_Pz8_';
+
+            let returnedText = helpers.formatSubtitleText(text);
+
+            expect(returnedText).to.equal(expectedText);
+        });
+
+        it('replaces all returned + symbols with -', () => {
+            let text = '>>>>>>';
+            let expectedText = 'Pj4-Pj4-';
+
+            let returnedText = helpers.formatSubtitleText(text);
+
+            expect(returnedText).to.equal(expectedText);
+        });
+    });
+});


### PR DESCRIPTION
The characters `/` and `+` were returning a 400 from frinkiac, so this fixes that.
Also sneaking in a change to only deploy to NPM when tagged because it needs doing so why not.